### PR TITLE
Add CI workflow to publish npm package with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish package to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --passWithNoTests
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Every pull request is analyzed with CodeQL to ensure the code remains secure.
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://badge.fury.io/js/bitbucket-mcp.svg)](https://www.npmjs.com/package/bitbucket-mcp)
 
+## Publishing & npm provenance
+
+Releases are published to npm using a GitHub Actions workflow that enables
+[npm provenance](https://docs.npmjs.com/generating-provenance-statements). The
+workflow runs the full test suite, builds the project, and publishes with
+`npm publish --provenance`, providing a cryptographic link between the published
+package and the repository commit that produced it.
+
+To publish a new version:
+
+1. Create a GitHub release or trigger the **Publish package to npm** workflow
+   manually.
+2. Ensure the repository has an `NPM_TOKEN` secret with `publish` rights to the
+   `bitbucket-mcp` package.
+3. The workflow will handle the rest, including generating the provenance
+   attestation automatically.
+
 ## Overview
 
 Checkout out the [official npm package](https://www.npmjs.com/package/bitbucket-mcp)


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and publishes the package with npm provenance
- document the release process and provenance-enabled publishing in the README

## Testing
- npm test -- --passWithNoTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7a9d6b848325a8ca227caa47d9dd)