### PR TITLE
Add MCP registry manifest generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,25 @@ npm run build
 npm run dev
 ```
 
+## Publishing to the MCP Registry
+
+Use the official Model Context Protocol publishing guide when you are ready to make a new server release. The repository includes
+everything that guide expects:
+
+1. Build the project so `dist/index.js` is up to date:
+   ```bash
+   npm run build
+   ```
+2. Generate the registry manifest (this reads `package.json` and emits `registry/bitbucket-mcp.manifest.json`):
+   ```bash
+   npm run registry:manifest
+   ```
+3. Follow the [publish-server guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md)
+   to push the manifest with `smithery publish` or the recommended workflow from the guide.
+
+The generated manifest captures the CLI command (`node dist/index.js`), all documented configuration options, and pointers back to
+this README for setup instructions, so it can be submitted directly to the MCP registry.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "release": "npm run publish:patch",
     "test": "jest",
     "lint": "eslint src/**/*.ts",
-    "inspector": "npx @modelcontextprotocol/inspector dist/index.js"
+    "inspector": "npx @modelcontextprotocol/inspector dist/index.js",
+    "registry:manifest": "node scripts/generate-registry-manifest.cjs"
   },
   "keywords": [
     "bitbucket",

--- a/registry/bitbucket-mcp.manifest.json
+++ b/registry/bitbucket-mcp.manifest.json
@@ -1,0 +1,91 @@
+{
+  "name": "Bitbucket MCP",
+  "slug": "bitbucket-mcp",
+  "version": "5.0.2",
+  "description": "Model Context Protocol (MCP) server for Bitbucket Cloud and Server API integration",
+  "homepage": "https://github.com/MatanYemini/bitbucket-mcp#readme",
+  "repository": "https://github.com/MatanYemini/bitbucket-mcp",
+  "license": "MIT",
+  "author": "Bitbucket MCP Team",
+  "keywords": [
+    "bitbucket",
+    "bitbucket-cloud",
+    "bitbucket-server",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "llm"
+  ],
+  "icon": "https://bitbucket.org/favicon.ico",
+  "transport": "stdio",
+  "startCommand": {
+    "command": "node",
+    "args": [
+      "dist/index.js"
+    ]
+  },
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "BITBUCKET_URL": {
+        "type": "string",
+        "description": "Bitbucket API URL (defaults to https://api.bitbucket.org/2.0)",
+        "default": "https://api.bitbucket.org/2.0"
+      },
+      "BITBUCKET_TOKEN": {
+        "type": "string",
+        "description": "Bitbucket access token for authentication"
+      },
+      "BITBUCKET_USERNAME": {
+        "type": "string",
+        "description": "Bitbucket username (used with password authentication)"
+      },
+      "BITBUCKET_PASSWORD": {
+        "type": "string",
+        "description": "Bitbucket app password (used with username authentication)",
+        "format": "password"
+      },
+      "BITBUCKET_WORKSPACE": {
+        "type": "string",
+        "description": "Default Bitbucket workspace to use when not specified"
+      },
+      "BITBUCKET_ENABLE_DANGEROUS": {
+        "type": "string",
+        "description": "Set to true to enable dangerous tools (e.g., deletions)"
+      },
+      "BITBUCKET_LOG_DISABLE": {
+        "type": "string",
+        "description": "Disable file logging when set to true/1"
+      },
+      "BITBUCKET_LOG_FILE": {
+        "type": "string",
+        "description": "Absolute path to a specific log file"
+      },
+      "BITBUCKET_LOG_DIR": {
+        "type": "string",
+        "description": "Directory where logs will be written (default is OS-specific)"
+      },
+      "BITBUCKET_LOG_PER_CWD": {
+        "type": "string",
+        "description": "When true, create a per-working-directory subfolder under BITBUCKET_LOG_DIR"
+      }
+    },
+    "oneOf": [
+      {
+        "required": [
+          "BITBUCKET_TOKEN"
+        ]
+      },
+      {
+        "required": [
+          "BITBUCKET_USERNAME",
+          "BITBUCKET_PASSWORD"
+        ]
+      }
+    ]
+  },
+  "documentation": {
+    "guide": "https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md",
+    "setup": "See README.md for full configuration instructions."
+  }
+}

--- a/scripts/generate-registry-manifest.cjs
+++ b/scripts/generate-registry-manifest.cjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.join(__dirname, '..');
+const pkgPath = path.join(rootDir, 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+const manifest = {
+  name: 'Bitbucket MCP',
+  slug: 'bitbucket-mcp',
+  version: pkg.version,
+  description: pkg.description,
+  homepage: pkg.homepage,
+  repository: pkg.repository?.url?.replace(/^git\+/, '') || null,
+  license: pkg.license,
+  author: pkg.author,
+  keywords: pkg.keywords,
+  icon: 'https://bitbucket.org/favicon.ico',
+  transport: 'stdio',
+  startCommand: {
+    command: 'node',
+    args: ['dist/index.js']
+  },
+  configSchema: {
+    type: 'object',
+    properties: {
+      BITBUCKET_URL: {
+        type: 'string',
+        description: 'Bitbucket API URL (defaults to https://api.bitbucket.org/2.0)',
+        default: 'https://api.bitbucket.org/2.0'
+      },
+      BITBUCKET_TOKEN: {
+        type: 'string',
+        description: 'Bitbucket access token for authentication'
+      },
+      BITBUCKET_USERNAME: {
+        type: 'string',
+        description: 'Bitbucket username (used with password authentication)'
+      },
+      BITBUCKET_PASSWORD: {
+        type: 'string',
+        description: 'Bitbucket app password (used with username authentication)',
+        format: 'password'
+      },
+      BITBUCKET_WORKSPACE: {
+        type: 'string',
+        description: 'Default Bitbucket workspace to use when not specified'
+      },
+      BITBUCKET_ENABLE_DANGEROUS: {
+        type: 'string',
+        description: 'Set to true to enable dangerous tools (e.g., deletions)'
+      },
+      BITBUCKET_LOG_DISABLE: {
+        type: 'string',
+        description: 'Disable file logging when set to true/1'
+      },
+      BITBUCKET_LOG_FILE: {
+        type: 'string',
+        description: 'Absolute path to a specific log file'
+      },
+      BITBUCKET_LOG_DIR: {
+        type: 'string',
+        description: 'Directory where logs will be written (default is OS-specific)'
+      },
+      BITBUCKET_LOG_PER_CWD: {
+        type: 'string',
+        description: 'When true, create a per-working-directory subfolder under BITBUCKET_LOG_DIR'
+      }
+    },
+    oneOf: [
+      { required: ['BITBUCKET_TOKEN'] },
+      { required: ['BITBUCKET_USERNAME', 'BITBUCKET_PASSWORD'] }
+    ]
+  },
+  documentation: {
+    guide: 'https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md',
+    setup: 'See README.md for full configuration instructions.'
+  }
+};
+
+const outputDir = path.join(rootDir, 'registry');
+fs.mkdirSync(outputDir, { recursive: true });
+const outputPath = path.join(outputDir, 'bitbucket-mcp.manifest.json');
+fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`Registry manifest updated at ${path.relative(rootDir, outputPath)}`);


### PR DESCRIPTION
## Summary
- add a reusable script that emits a registry-ready manifest from package metadata and configuration
- check the manifest into the repo and document the publishing steps in the README
- expose an npm script so the manifest can be regenerated before publishing

## Testing
- npm run registry:manifest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199498483c8325ac9ca9d62ffe87e1)