### PR TITLE
Feat: Add getEffectiveDefaultReviewers method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1835,6 +1835,21 @@ class BitbucketServer {
             required: ["workspace", "repo_slug", "pull_request_id"],
           },
         },
+        {
+          name: "getEffectiveDefaultReviewers",
+          description: "Get effective default reviewers for a repository",
+          inputSchema: {
+            type: "object",
+            properties: {
+              workspace: {
+                type: "string",
+                description: "Bitbucket workspace name",
+              },
+              repo_slug: { type: "string", description: "Repository slug" },
+            },
+            required: ["workspace", "repo_slug"],
+          },
+        },
       ].filter(
         (tool) =>
           this.config.allowDangerousCommands === true ||
@@ -2236,6 +2251,11 @@ class BitbucketServer {
               args.page as number,
               args.all as boolean
             );
+          case "getEffectiveDefaultReviewers":
+            return await this.getEffectiveDefaultReviewers(
+              args.workspace as string,
+              args.repo_slug as string
+            );
           default:
             throw new McpError(
               ErrorCode.MethodNotFound,
@@ -2343,6 +2363,40 @@ class BitbucketServer {
       throw new McpError(
         ErrorCode.InternalError,
         `Failed to get repository: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  async getEffectiveDefaultReviewers(workspace: string, repo_slug: string) {
+    try {
+      logger.info("Getting effective default reviewers", {
+        workspace,
+        repo_slug,
+      });
+
+      const response = await this.api.get(
+        `/repositories/${workspace}/${repo_slug}/effective-default-reviewers`
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(response.data, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error("Error getting effective default reviewers", {
+        error,
+        workspace,
+        repo_slug,
+      });
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to get effective default reviewers: ${
           error instanceof Error ? error.message : String(error)
         }`
       );


### PR DESCRIPTION
## Feature: Add getEffectiveDefaultReviewers tool

### Summary
Adds a new MCP tool to retrieve effective default reviewers for a Bitbucket repository. This allows users to fetch the list of default reviewers configured for a repository, which can be used when creating pull requests.

### Changes Made

1. **New MCP Tool:**
   - Added `getEffectiveDefaultReviewers` tool to the tools array
   - Tool accepts `workspace` and `repo_slug` as required parameters
   - Returns effective default reviewers data in JSON format

2. **Implementation:**
   - Added handler case in the switch statement for the new tool
   - Implemented `getEffectiveDefaultReviewers()` method in `BitbucketServer` class
   - Follows the same error handling pattern as other repository methods

3. **API Integration:**
   - Calls Bitbucket API endpoint: `GET /repositories/{workspace}/{repo_slug}/effective-default-reviewers`
   - Returns the complete response from the API

### Technical Details

The tool calls the Bitbucket API endpoint:
```
GET /repositories/{workspace}/{repo_slug}/effective-default-reviewers
```

This endpoint returns the effective default reviewers for the repository, which includes reviewers configured at both the repository and project levels.

**Example Usage:**
```json
{
  "workspace": "my-workspace",
  "repo_slug": "my-repo"
}
```

**Response:**
Returns the effective default reviewers data as returned by the Bitbucket API, which can be used to populate reviewers when creating pull requests.

### Impact

- ✅ Enables users to fetch effective default reviewers for any repository
- ✅ Provides a way to discover default reviewers before creating PRs
- ✅ Maintains consistency with existing tool patterns and error handling
- ✅ No breaking changes to existing functionality

### Use Case

Users can now:
1. Call `getEffectiveDefaultReviewers` to fetch default reviewers for a repository
2. Use the returned reviewer information when creating pull requests
3. Understand which reviewers will be automatically assigned based on repository/project settings
