### PR TITLE
fix 400 in approvePullRequest when using new api tokens

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -548,11 +548,13 @@ class BitbucketServer {
     }
 
     // Setup Axios instance
+    const headers: Record<string, string> = {};
+    if (this.config.token) {
+      headers.Authorization = `Bearer ${this.config.token}`;
+    }
     this.api = axios.create({
       baseURL: this.config.baseUrl,
-      headers: this.config.token
-        ? { Authorization: `Bearer ${this.config.token}` }
-        : { "Content-Type": "application/json" },
+      headers,
       auth:
         this.config.username && this.config.password
           ? { username: this.config.username, password: this.config.password }


### PR DESCRIPTION
approvePullRequest was not possible with an API Token. 

It always returned

```
{
  "error": "MCP error -32603: MCP error -32603: Failed to approve pull request: Request failed with status code 400"
}
```

Not sure if this is a quirk in how the bitbucket api works or just that endpoint.
But other other calls like addPullRequestComment worked just fine with the exact same setup. 

This makes the approvePullRequest succeed 
