### PR TITLE
feat(pipelines): add sort parameter to listPipelineRuns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1341,6 +1341,11 @@ class BitbucketServer {
                 enum: ["manual", "push", "pullrequest", "schedule"],
                 description: "Filter pipelines by trigger type",
               },
+              sort: {
+                type: "string",
+                description:
+                  "Field to sort by. Prefix with '-' for descending order. Supported fields: created_on, creator.uuid. Example: '-created_on' for newest first.",
+              },
             },
             required: ["workspace", "repo_slug"],
           },
@@ -2103,7 +2108,8 @@ class BitbucketServer {
                 | "push"
                 | "pullrequest"
                 | "schedule",
-              args.limit as number
+              args.limit as number,
+              args.sort as string
             );
           case "getPipelineRun":
             return await this.getPipelineRun(
@@ -3869,7 +3875,8 @@ class BitbucketServer {
       | "STOPPED",
     target_branch?: string,
     trigger_type?: "manual" | "push" | "pullrequest" | "schedule",
-    legacyLimit?: number
+    legacyLimit?: number,
+    sort?: string
   ) {
     try {
       logger.info("Listing pipeline runs", {
@@ -3881,12 +3888,14 @@ class BitbucketServer {
         status,
         target_branch,
         trigger_type,
+        sort,
       });
 
       const params: Record<string, any> = {};
       if (status) params.status = status;
       if (target_branch) params["target.branch"] = target_branch;
       if (trigger_type) params.trigger_type = trigger_type;
+      if (sort) params.sort = sort;
 
       const result = await this.paginator.fetchValues(
         `/repositories/${workspace}/${repo_slug}/pipelines`,


### PR DESCRIPTION
## Summary

Add support for the `sort` parameter in `listPipelineRuns` tool, allowing users to sort pipeline runs by fields like `created_on` or `creator.uuid`.

## Problem

As reported in #61, the Bitbucket API supports sorting pipeline runs via the `sort` query parameter (see [API docs](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pipelines/#api-repositories-workspace-repo-slug-pipelines-get-request-Query%20parameters)), but this MCP tool was not passing the parameter through to the API.

This caused the tool to always return pipelines in ascending order (oldest first), making it impractical for users who want to see the most recent pipeline runs.

## Solution

- Added `sort` property to the `listPipelineRuns` tool schema with description explaining usage
- Updated the case handler to pass the sort parameter to the method
- Updated the method to include `sort` in the API request params

## Usage

```json
{
  "workspace": "my-workspace",
  "repo_slug": "my-repo",
  "sort": "-created_on",
  "pagelen": 10
}
```

Use `-` prefix for descending order. Supported fields per Bitbucket API:
- `created_on`
- `creator.uuid`

## Testing

- `npm run build` ✅
- `npm test` ✅ (3 tests pass)

Fixes #61