### PR TITLE
Add dotenv support for environment variable configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.1.1",
         "axios": "^1.6.5",
+        "dotenv": "^17.3.1",
         "winston": "^3.11.0"
       },
       "bin": {
@@ -2934,6 +2935,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -52,16 +52,17 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.1.1",
     "axios": "^1.6.5",
+    "dotenv": "^17.3.1",
     "winston": "^3.11.0"
   },
   "devDependencies": {
-    "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.24",
     "@typescript-eslint/eslint-plugin": "^7.0.2",
     "@typescript-eslint/parser": "^7.0.2",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "dotenv/config";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {


### PR DESCRIPTION
## Summary
This PR adds support for loading environment variables from a `.env` file using the `dotenv` package, enabling easier configuration management for the application.

## Changes
- Added `dotenv` as a production dependency
- Imported and initialized `dotenv/config` at the entry point of the application (`src/index.ts`)
- Reorganized `package.json` devDependencies for better alphabetical ordering

## Implementation Details
The `dotenv/config` import is placed at the very top of `src/index.ts` (after the shebang) to ensure environment variables are loaded before any other modules are initialized. This allows the application to read configuration from a `.env` file in the project root, with environment variables taking precedence over file-based configuration.

https://claude.ai/code/session_018yPgG9te9Fe7CZ2bu3DLA8