### PR TITLE
Fix BitbucketServer API post request with empty body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4500,7 +4500,7 @@ class BitbucketServer {
       }
 
       const response = resolved
-        ? await this.api.post(resolveUrl(targetCommentId))
+        ? await this.api.post(resolveUrl(targetCommentId), {})
         : await this.api.delete(resolveUrl(targetCommentId));
 
       const responseText =


### PR DESCRIPTION
## Summary
Fixed a bug in the BitbucketServer class where the `post` API call was missing a required body parameter when resolving comments.

## Key Changes
- Added an empty object `{}` as the body parameter to the `api.post()` call in the comment resolution flow
- This ensures the POST request is properly formatted with a body, even when no data needs to be sent

## Implementation Details
The change affects the comment resolution logic in `BitbucketServer.ts`. When a comment is being resolved (as opposed to deleted), the API post request now explicitly passes an empty object as the request body. This aligns with the expected API contract and prevents potential issues with the HTTP client handling requests without a body parameter.
