### PR TITLE
feat: add parent_id for threaded comment replies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -938,6 +938,11 @@ class BitbucketServer {
                 },
                 required: ["path"],
               },
+              parent_id: {
+                type: "number",
+                description:
+                  "ID of the parent comment to reply to. Use this to create a threaded reply to an existing comment.",
+              },
             },
             required: ["workspace", "repo_slug", "pull_request_id", "content"],
           },
@@ -983,6 +988,11 @@ class BitbucketServer {
                   },
                 },
                 required: ["path"],
+              },
+              parent_id: {
+                type: "number",
+                description:
+                  "ID of the parent comment to reply to. Use this to create a threaded reply to an existing comment.",
               },
             },
             required: ["workspace", "repo_slug", "pull_request_id", "content"],
@@ -1998,7 +2008,8 @@ class BitbucketServer {
               args.pull_request_id as string,
               args.content as string,
               args.inline as InlineCommentInline,
-              args.pending as boolean
+              args.pending as boolean,
+              args.parent_id as number | undefined
             );
           case "addPendingPullRequestComment":
             return await this.addPendingPullRequestComment(
@@ -2006,7 +2017,8 @@ class BitbucketServer {
               args.repo_slug as string,
               args.pull_request_id as string,
               args.content as string,
-              args.inline as InlineCommentInline
+              args.inline as InlineCommentInline,
+              args.parent_id as number | undefined
             );
           case "publishPendingComments":
             return await this.publishPendingComments(
@@ -3036,7 +3048,8 @@ class BitbucketServer {
     pull_request_id: string,
     content: string,
     inline?: InlineCommentInline,
-    pending?: boolean
+    pending?: boolean,
+    parent_id?: number
   ) {
     try {
       logger.info("Adding comment to Bitbucket pull request", {
@@ -3056,6 +3069,11 @@ class BitbucketServer {
       // Add pending flag if provided
       if (pending !== undefined) {
         commentData.pending = pending;
+      }
+
+      // Add parent comment ID if provided (for threaded replies)
+      if (parent_id !== undefined) {
+        commentData.parent = { id: parent_id };
       }
 
       // Add inline information if provided
@@ -3386,7 +3404,8 @@ class BitbucketServer {
     repo_slug: string,
     pull_request_id: string,
     content: string,
-    inline?: InlineCommentInline
+    inline?: InlineCommentInline,
+    parent_id?: number
   ) {
     try {
       logger.info("Adding pending comment to Bitbucket pull request", {
@@ -3403,7 +3422,8 @@ class BitbucketServer {
         pull_request_id,
         content,
         inline,
-        true // Set pending to true for draft comment
+        true, // Set pending to true for draft comment
+        parent_id
       );
     } catch (error) {
       logger.error("Error adding pending comment to pull request", {


### PR DESCRIPTION
## Summary

Adds `parent_id` parameter to `addPullRequestComment` and `addPendingPullRequestComment` tools to enable creating threaded replies to existing PR comments.

This maps to the Bitbucket API's `parent.id` field in the [comment creation endpoint](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-comments-post).

## Changes

- Added `parent_id` (optional `number`) to the `inputSchema` for both `addPullRequestComment` and `addPendingPullRequestComment`
- Pass `parent_id` through the handler dispatch to the implementation methods
- When `parent_id` is provided, include `parent: { id: parent_id }` in the API request body

## Usage

```json
{
  "workspace": "my-workspace",
  "repo_slug": "my-repo",
  "pull_request_id": "123",
  "content": "Great point, I'll fix this.",
  "parent_id": 456
}
```

This creates a threaded reply under comment ID 456.

## Test plan

- [x] Verified `parent_id` appears in tool schema after restart
- [x] Tested creating a reply to an existing comment via the MCP tool
- [x] Confirmed backwards compatibility — omitting `parent_id` works as before