### PR TITLE
Bump version to 5.0.7 — publish fix for 400 on empty-body POST endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucket-mcp",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Model Context Protocol (MCP) server for Bitbucket Cloud and Server API integration",
   "mcpName": "io.github.MatanYemini/bitbucket-mcp",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bumps version from 5.0.6 to 5.0.7

## Why

The fix for 400 errors on `approvePullRequest` (merged in 3adcc91) was never published to npm. Users running `npx bitbucket-mcp@latest` still get v5.0.6 which has the bug — `Content-Type: application/json` is set as a default header on the axios instance, causing Bitbucket to reject empty-body POST requests with HTTP 400.

Affected endpoints:
- `approvePullRequest` (`POST .../approve`)
- `resolveComment` (`POST .../resolve`)
- `stopPipeline` (`POST .../stop`)

All three work correctly after the header fix in 3adcc91, but only if a new npm version is published.

## Test

```bash
# Before (v5.0.6): HTTP 400 "Bad Request"
# After (v5.0.7): HTTP 200 with approval response
```