### PR TITLE
fix: bump version to 5.0.7 to publish empty-body POST fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbucket-mcp",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "Model Context Protocol (MCP) server for Bitbucket Cloud and Server API integration",
   "mcpName": "io.github.MatanYemini/bitbucket-mcp",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps version from 5.0.6 to 5.0.7 so the fix for HTTP 400 errors on empty-body POST endpoints gets published to npm.

## Changes

- Updated `package.json` version from `5.0.6` to `5.0.7`

## Context

The root cause fix was merged in 3adcc91 — it removed the default `Content-Type: application/json` header from the axios instance. When using app password authentication (Basic auth), this header was set on every request including empty-body POSTs, causing Bitbucket to reject them with HTTP 400 "Bad Request".

However, v5.0.6 on npm was published **before** that fix was merged, so users running `npx bitbucket-mcp@latest` still get the broken version.

### Affected endpoints

| Endpoint | Method | Issue |
|----------|--------|-------|
| `approvePullRequest` | `POST .../approve` | Empty body + `Content-Type: application/json` → 400 |
| `resolveComment` | `POST .../resolve` | Same |
| `stopPipeline` | `POST .../stop` | Same |

## Test plan

- [x] Verified `approvePullRequest` returns HTTP 400 on v5.0.6 with app password auth
- [x] Built from current master (with 3adcc91 fix) — `approvePullRequest` returns HTTP 200
- [x] Confirmed `resolveComment` and `stopPipeline` also work with empty-body POST after the fix
- [x] Backwards compatible — no behavior change for OAuth Bearer token users