### PR TITLE
fix: PR task tools (correct URL paths, body shape, state enum)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4733,7 +4733,9 @@ class BitbucketServer {
         task_id,
       });
 
-      const response = await this.api.get(`/tasks/${task_id}`);
+      const response = await this.api.get(
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks/${task_id}`
+      );
 
       return {
         content: [
@@ -4777,7 +4779,10 @@ class BitbucketServer {
       if (content !== undefined) data.content = content;
       if (state !== undefined) data.state = state;
 
-      const response = await this.api.put(`/tasks/${task_id}`, data);
+      const response = await this.api.put(
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks/${task_id}`,
+        data
+      );
 
       return {
         content: [
@@ -4815,7 +4820,9 @@ class BitbucketServer {
         task_id,
       });
 
-      await this.api.delete(`/tasks/${task_id}`);
+      await this.api.delete(
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks/${task_id}`
+      );
 
       return {
         content: [{ type: "text", text: "Task deleted successfully." }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1745,11 +1745,6 @@ class BitbucketServer {
                 type: "number",
                 description: "Optional comment ID to attach the task",
               },
-              state: {
-                type: "string",
-                enum: ["OPEN", "RESOLVED"],
-                description: "Initial task state",
-              },
             },
             required: ["workspace", "repo_slug", "pull_request_id", "content"],
           },
@@ -1793,7 +1788,7 @@ class BitbucketServer {
               content: { type: "string", description: "Updated task content" },
               state: {
                 type: "string",
-                enum: ["OPEN", "RESOLVED"],
+                enum: ["UNRESOLVED", "RESOLVED"],
                 description: "Updated task state",
               },
             },
@@ -2220,8 +2215,7 @@ class BitbucketServer {
               args.repo_slug as string,
               args.pull_request_id as string,
               args.content as string,
-              args.comment as number,
-              args.state as "OPEN" | "RESOLVED"
+              args.comment as number
             );
           case "getPullRequestTask":
             return await this.getPullRequestTask(
@@ -2237,7 +2231,7 @@ class BitbucketServer {
               args.pull_request_id as string,
               args.task_id as string,
               args.content as string | undefined,
-              args.state as ("OPEN" | "RESOLVED") | undefined
+              args.state as ("UNRESOLVED" | "RESOLVED") | undefined
             );
           case "deletePullRequestTask":
             return await this.deletePullRequestTask(
@@ -4679,8 +4673,7 @@ class BitbucketServer {
     repo_slug: string,
     pull_request_id: string,
     content: string,
-    commentId?: number,
-    state?: "OPEN" | "RESOLVED"
+    commentId?: number
   ) {
     try {
       logger.info("Creating pull request task", {
@@ -4689,9 +4682,8 @@ class BitbucketServer {
         pull_request_id,
       });
 
-      const data: Record<string, any> = { content };
+      const data: Record<string, any> = { content: { raw: content } };
       if (commentId) data.comment = { id: commentId };
-      if (state) data.state = state;
 
       const response = await this.api.post(
         `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks`,
@@ -4765,7 +4757,7 @@ class BitbucketServer {
     pull_request_id: string,
     task_id: string,
     content?: string,
-    state?: "OPEN" | "RESOLVED"
+    state?: "UNRESOLVED" | "RESOLVED"
   ) {
     try {
       logger.info("Updating pull request task", {
@@ -4776,7 +4768,7 @@ class BitbucketServer {
       });
 
       const data: Record<string, any> = {};
-      if (content !== undefined) data.content = content;
+      if (content !== undefined) data.content = { raw: content };
       if (state !== undefined) data.state = state;
 
       const response = await this.api.put(


### PR DESCRIPTION
## Summary

Three bugs in the PR task tools (`getPullRequestTask`, `createPullRequestTask`, `updatePullRequestTask`, `deletePullRequestTask`) made them unusable against Bitbucket Cloud. This PR fixes all of them, split across two focused commits.

### Commit 1 — fix: use full repository path for getPullRequestTask, updatePullRequestTask, deletePullRequestTask

The three task tools were calling `/tasks/${task_id}` directly, which is not a valid Bitbucket Cloud endpoint. The correct path scopes the task ID under its owning repository and pull request:

```
/repositories/{workspace}/{repo_slug}/pullrequests/{pull_request_id}/tasks/{task_id}
```

Without this fix, `getPullRequestTask`, `updatePullRequestTask`, and `deletePullRequestTask` all fail at the HTTP layer.

### Commit 2 — fix: correct PR task body shape, fix state enum, drop unsupported state-on-create

1. **Body-shape fix.** `createPullRequestTask` and `updatePullRequestTask` were sending `{ content: "<string>" }` to Bitbucket, which expects `{ content: { raw: "<string>" } }` (the same shape `addPullRequestComment` already uses). Result: every create returned HTTP 400, and every content-bearing update returned HTTP 400.

2. **State enum fix.** The `state` enum on both tools was declared `["OPEN", "RESOLVED"]`, but Bitbucket's actual values are `["UNRESOLVED", "RESOLVED"]`. Passing the correct value `"UNRESOLVED"` was rejected by the MCP tool schema as out-of-enum, while passing `"OPEN"` would have been forwarded to Bitbucket and rejected with HTTP 400.

3. **Drop `state` from create.** Removed entirely from `createPullRequestTask`. Bitbucket's `POST /tasks` endpoint silently ignores any `state` value supplied at creation — tasks are always born `UNRESOLVED` — so advertising the parameter in the tool schema was misleading. State transitions should go through `updatePullRequestTask`, which keeps the `state` parameter (with the corrected enum).

## Test plan

Verified end-to-end against a live Bitbucket Cloud PR (full results captured locally; summary below):

- [x] `getPullRequestTasks` (list) succeeds
- [x] `getPullRequestTask` (single) succeeds with full URL path
- [x] `createPullRequestTask` with `content` only succeeds; returns task with `state=UNRESOLVED` and matching `content.raw`
- [x] `createPullRequestTask` with stray `state` arg ignores the arg (returns UNRESOLVED — no way to back-door RESOLVED-on-create)
- [x] `updatePullRequestTask` with `content` only succeeds and updates `content.raw`
- [x] `updatePullRequestTask` with `state: "RESOLVED"` succeeds and flips state, content preserved
- [x] `updatePullRequestTask` with `state: "UNRESOLVED"` succeeds (was previously rejected by the schema as out-of-enum)
- [x] `updatePullRequestTask` with `content + state` together succeeds, both fields updated
- [x] `tsc` build is clean