### PR TITLE
Fix/resolve body and comment threading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -894,7 +894,8 @@ class BitbucketServer {
         },
         {
           name: "addPullRequestComment",
-          description: "Add a comment to a pull request (general or inline)",
+          description:
+            "Add a comment to a pull request (general, inline, or a threaded reply to another comment)",
           inputSchema: {
             type: "object",
             properties: {
@@ -916,10 +917,15 @@ class BitbucketServer {
                 description:
                   "Whether to create this comment as a pending comment (draft state)",
               },
+              parent_id: {
+                type: "number",
+                description:
+                  "If set, posts this comment as a threaded reply to the given comment id. The reply inherits the parent's inline anchor (if any); do not also pass `inline` when replying.",
+              },
               inline: {
                 type: "object",
                 description:
-                  "Inline comment information for commenting on specific lines",
+                  "Inline comment information for commenting on specific lines. Ignored when `parent_id` is set.",
                 properties: {
                   path: {
                     type: "string",
@@ -1998,7 +2004,8 @@ class BitbucketServer {
               args.pull_request_id as string,
               args.content as string,
               args.inline as InlineCommentInline,
-              args.pending as boolean
+              args.pending as boolean,
+              args.parent_id as number | undefined
             );
           case "addPendingPullRequestComment":
             return await this.addPendingPullRequestComment(
@@ -3039,14 +3046,19 @@ class BitbucketServer {
     pull_request_id: string,
     content: string,
     inline?: InlineCommentInline,
-    pending?: boolean
+    pending?: boolean,
+    parent_id?: number
   ) {
     try {
       logger.info("Adding comment to Bitbucket pull request", {
         workspace,
         repo_slug,
         pull_request_id,
-        inline: inline ? "inline comment" : "general comment",
+        mode: parent_id
+          ? "threaded reply"
+          : inline
+          ? "inline comment"
+          : "general comment",
       });
 
       // Prepare the comment data
@@ -3061,13 +3073,15 @@ class BitbucketServer {
         commentData.pending = pending;
       }
 
-      // Add inline information if provided
-      if (inline) {
+      // Threaded reply: inherit the parent's inline anchor; ignore any `inline`
+      // arg the caller supplied to avoid Bitbucket 400s from conflicting anchors.
+      if (parent_id !== undefined && parent_id !== null) {
+        commentData.parent = { id: parent_id };
+      } else if (inline) {
         commentData.inline = {
           path: inline.path,
         };
 
-        // Add line number information based on the type
         if (inline.from !== undefined) {
           commentData.inline.from = inline.from;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2708,8 +2708,11 @@ class BitbucketServer {
         pull_request_id,
       });
 
+      // Bitbucket Cloud returns 400 when this POST carries no body or no
+      // Content-Type. Pass `{}` so axios infers `application/json`.
       const response = await this.api.post(
-        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/approve`
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/approve`,
+        {}
       );
 
       return {
@@ -4055,8 +4058,11 @@ class BitbucketServer {
         pipeline_uuid,
       });
 
+      // Bitbucket Cloud returns 400 when this POST carries no body or no
+      // Content-Type. Pass `{}` so axios infers `application/json`.
       const response = await this.api.post(
-        `/repositories/${workspace}/${repo_slug}/pipelines/${pipeline_uuid}/stop`
+        `/repositories/${workspace}/${repo_slug}/pipelines/${pipeline_uuid}/stop`,
+        {}
       );
 
       return {
@@ -4499,8 +4505,11 @@ class BitbucketServer {
         targetCommentId = comment_id;
       }
 
+      // Bitbucket Cloud requires POST /resolve to carry a JSON body (at minimum `{}`)
+      // and a matching Content-Type header; otherwise the gateway returns 400.
+      // Pass an explicit empty-object body so axios sets `Content-Type: application/json`.
       const response = resolved
-        ? await this.api.post(resolveUrl(targetCommentId))
+        ? await this.api.post(resolveUrl(targetCommentId), {})
         : await this.api.delete(resolveUrl(targetCommentId));
 
       const responseText =


### PR DESCRIPTION
## Summary

Two small, related fixes for Bitbucket Cloud interactions that were silently broken after #73 ("fix 400 in approvePullRequest when using new api tokens"), plus a long-missing feature for threaded review replies.

### 1. `fix: send empty JSON body on body-less POSTs` — commit 4b73534

Since 3adcc91 the axios instance no longer sets a default `Content-Type: application/json` when using username/password auth. Combined with `this.api.post(url)` called with no body argument — which axios sends as a body-less, header-less request — Bitbucket Cloud returns HTTP 400 for endpoints that require a JSON body, even when the body is semantically empty.

Affected:
- `POST .../comments/{id}/resolve` (`resolveComment`)
- `POST .../pullrequests/{id}/approve` (`approvePullRequest`)
- `POST .../pipelines/{uuid}/stop` (`stopPipeline`)

Fix: pass explicit `{}` as the second arg — axios then infers `Content-Type: application/json` and Bitbucket accepts.

Reproduced against live Bitbucket Cloud: direct curl with `-d '{}' -H 'Content-Type: application/json'` returns 200; MCP tool now matches.

### 2. `feat(addPullRequestComment): support threaded replies via parent_id` — commit 144c58b

Bitbucket accepts `parent: { id }` on `POST .../comments` to thread a reply under an existing comment and inherit its inline anchor. The MCP tool didn't expose this, so agents posting review responses had to either (a) create new top-level comments (losing thread context) or (b) reconstruct the inline anchor and hope for the best (often 400s from conflicting anchors).

This adds a `parent_id: number` property to `addPullRequestComment`. When set:
- Body emits `parent: { id }`.
- Any `inline` the caller passed is ignored (avoids Bitbucket 400s from conflicting anchors — the parent's anchor is inherited automatically).

Omitting `parent_id` preserves prior behaviour byte-for-byte. No schema break.

## Verification

- `npx tsc --noEmit` — clean.
- `npm test` — existing pagination tests pass (3/3).
- Live-tested end-to-end against Bitbucket Cloud on a real PR:
  - 17 threaded replies posted via `parent_id` (response `parent.id` matches, replies render under the right inline thread in the UI).
  - 17 resolves succeeded with the empty-body fix (`HTTP 200`).
  - Child-comment resolution returns the expected `"Comment is not a top-level comment"` error — the existing parent-walk logic in `setCommentResolved` continues to handle that gracefully.

## Note on scope

Kept to the minimum surface needed to unbreak write-side Bitbucket workflows. Didn't add unit tests because the existing test harness only covers `BitbucketPaginator`; the `BitbucketServer` class would need a small axios-mocking fixture that felt out of scope for a bugfix PR. Happy to add one if you'd like — just let me know the shape you want.

Happy to split into two PRs if that's preferred; both commits are self-contained and independently revertable.