### PR TITLE
fix: wrap task content in raw object for Bitbucket API compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4722,9 +4722,9 @@ class BitbucketServer {
         pull_request_id,
       });
 
-      const data: Record<string, any> = { content };
+      const data: Record<string, any> = { content: { raw: content } };
       if (commentId) data.comment = { id: commentId };
-      if (state) data.state = state;
+      if (state) data.pending = state !== "RESOLVED";
 
       const response = await this.api.post(
         `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks`,
@@ -4807,8 +4807,8 @@ class BitbucketServer {
       });
 
       const data: Record<string, any> = {};
-      if (content !== undefined) data.content = content;
-      if (state !== undefined) data.state = state;
+      if (content !== undefined) data.content = { raw: content };
+      if (state !== undefined) data.state = state === "OPEN" ? "UNRESOLVED" : "RESOLVED";
 
       const response = await this.api.put(`/tasks/${task_id}`, data);
 


### PR DESCRIPTION
The Bitbucket API expects task content as { raw: string } not a plain string. Also map the OPEN/RESOLVED state enum to the API's pending boolean on create, and to UNRESOLVED/RESOLVED on update.