### PR TITLE
fix: remove Content-Type header from approvePullRequest POST

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2722,11 +2722,10 @@ class BitbucketServer {
         pull_request_id,
       });
 
-      // Bitbucket Cloud returns 400 when this POST carries no body or no
-      // Content-Type. Pass `{}` so axios infers `application/json`.
       const response = await this.api.post(
         `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/approve`,
-        {}
+        null,
+        { headers: { "Content-Type": undefined } }
       );
 
       return {


### PR DESCRIPTION
approvePullRequest returns 400 when using Basic Auth because the axios instance sets Content-Type: application/json as a default header on all requests, including the body-less POST to /approve which Bitbucket rejects. This fix clears the Content-Type header on that request so it does not inherit the instance-level default.