### PR TITLE
Fix createOrUpdatePullRequestTask payload shape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4689,7 +4689,7 @@ class BitbucketServer {
         pull_request_id,
       });
 
-      const data: Record<string, any> = { content };
+      const data: Record<string, any> = { content: { raw: content } };
       if (commentId) data.comment = { id: commentId };
       if (state) data.state = state;
 


### PR DESCRIPTION
## Summary

- Bitbucket Cloud's tasks API expects `content` as `{ raw: string }`, not a bare string.
- `createOrUpdatePullRequestTask` currently sends `{ content: "..." }`, which makes `POST /repositories/{workspace}/{repo}/pullrequests/{id}/tasks` return `400 Bad Request`.
- Wrap the string in `{ raw: content }` to match the documented payload shape.

Reference: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-tasks-post

## Test plan

- [ ] Call the `createPullRequestTask` MCP tool with `content: "do the thing"` against a real PR
- [ ] Confirm the task is created (no 400) and the rendered content matches the input
- [ ] Repeat with `commentId` and `state` set to verify those code paths still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)