### PR TITLE
Fix updatePullRequestTask endpoint and payload shape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4774,10 +4774,13 @@ class BitbucketServer {
       });
 
       const data: Record<string, any> = {};
-      if (content !== undefined) data.content = content;
+      if (content !== undefined) data.content = { raw: content };
       if (state !== undefined) data.state = state;
 
-      const response = await this.api.put(`/tasks/${task_id}`, data);
+      const response = await this.api.put(
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks/${task_id}`,
+        data
+      );
 
       return {
         content: [


### PR DESCRIPTION
## Summary

- `updatePullRequestTask` called `PUT /tasks/{task_id}` on the `api.bitbucket.org/2.0` base URL. That path is not a valid Bitbucket Cloud endpoint and returns 404 — task updates never worked.
- Switch to the documented nested path: `PUT /repositories/{workspace}/{repo}/pullrequests/{id}/tasks/{task_id}`.
- Also wrap `content` as `{ raw: content }` since the API rejects a bare string with a 400 (same shape fix as #123).

Reference: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-tasks-task-id-put

Note: `getPullRequestTask` and `deletePullRequestTask` still use the same broken `/tasks/{task_id}` path and likely need the same endpoint fix — happy to send follow-ups if useful, kept out of this PR to keep the change minimal.

## Test plan

- [ ] Create a task on a real PR, then call `updatePullRequestTask` with new `content` — expect 200 and updated content rendered
- [ ] Call with `state: "RESOLVED"` — expect the task to transition to resolved
- [ ] Confirm no regression for `createPullRequestTask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)