### PR TITLE
Fix getPullRequestTask and deletePullRequestTask endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4733,7 +4733,9 @@ class BitbucketServer {
         task_id,
       });
 
-      const response = await this.api.get(`/tasks/${task_id}`);
+      const response = await this.api.get(
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks/${task_id}`
+      );
 
       return {
         content: [
@@ -4815,7 +4817,9 @@ class BitbucketServer {
         task_id,
       });
 
-      await this.api.delete(`/tasks/${task_id}`);
+      await this.api.delete(
+        `/repositories/${workspace}/${repo_slug}/pullrequests/${pull_request_id}/tasks/${task_id}`
+      );
 
       return {
         content: [{ type: "text", text: "Task deleted successfully." }],


### PR DESCRIPTION
## Summary

- Both `getPullRequestTask` and `deletePullRequestTask` call `/tasks/{task_id}` against the `api.bitbucket.org/2.0` base URL. That path is not a valid Bitbucket Cloud endpoint and returns 404, so neither operation has ever worked.
- Switch to the documented nested path: `/repositories/{workspace}/{repo}/pullrequests/{id}/tasks/{task_id}`.
- This is the same endpoint fix as #124, applied to the GET and DELETE variants.

References:
- GET: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-tasks-task-id-get
- DELETE: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-tasks-task-id-delete

Note: `deletePullRequestTask` is already gated behind `BITBUCKET_ENABLE_DANGEROUS`, so this only affects users who have opted in to destructive operations.

## Test plan

- [ ] Create a task on a real PR, then call `getPullRequestTask` — expect 200 with the task body
- [ ] With `BITBUCKET_ENABLE_DANGEROUS=true`, call `deletePullRequestTask` on the same task — expect 204 and the task gone on a subsequent `getPullRequestTasks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)